### PR TITLE
Fix smartphone export preview alignment

### DIFF
--- a/src/components/frames-photo-tool.tsx
+++ b/src/components/frames-photo-tool.tsx
@@ -1495,7 +1495,9 @@ const FramesTool: React.FC = () => {
 
                 // キャプション描画
                 if (captionLines[0] || captionLines[1]) {
-                  drawCaption(outputCtx, outputW, outputH, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
+                  // モバイル用のキャプション位置調整: プレビューと同じcanvasHを使用
+                  const canvasHForCaption = isMobileDevice() ? canvasH : outputH;
+                  drawCaption(outputCtx, outputW, canvasHForCaption, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
                 }
 
                 // ダウンロード
@@ -1873,7 +1875,9 @@ const FramesTool: React.FC = () => {
 
                   // キャプション描画
                   if (captionLines[0] || captionLines[1]) {
-                    drawCaption(outputCtx, outputW, outputH, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
+                    // モバイル用のキャプション位置調整: プレビューと同じcanvasHを使用
+                    const canvasHForCaption = isMobileDevice() ? canvasH : outputH;
+                    drawCaption(outputCtx, outputW, canvasHForCaption, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
                   }
 
                   // ダウンロード
@@ -2175,7 +2179,9 @@ const FramesTool: React.FC = () => {
 
                   // キャプション描画
                   if (captionLines[0] || captionLines[1]) {
-                    drawCaption(outputCtx, outputW, outputH, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
+                    // モバイル用のキャプション位置調整: プレビューと同じcanvasHを使用
+                    const canvasHForCaption = isMobileDevice() ? canvasH : outputH;
+                    drawCaption(outputCtx, outputW, canvasHForCaption, padBottomOut, top, targetH, captionLines, frameColorOut, space, ratio, image?.width, image?.height);
                   }
 
                   // ダウンロード


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix mobile export caption positioning to match preview.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the preview used `canvasH` (mobile-adjusted height) for caption positioning, while export functions used `outputH` (non-mobile-adjusted height). This PR ensures export functions use `canvasH` for caption drawing on mobile devices, resolving the discrepancy.